### PR TITLE
Drop dangling bullet points

### DIFF
--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -41,11 +41,6 @@ already own related scope. Divergent requirements between such stakeholders
 may result in distinct units of work, but this determination is left to this
 first milestone of the Working Group.
 
-- Define reusable format(s) for Digital Emblems
-- Define validation mechanism(s) for Digital Emblems
-- Define discovery of Digital Emblems for Digital Assets
-- Define discovery of Digital Emblems for Physical Assets
-
 ### BoF v2 discussion TODO: should this WG adopt both digital and physical assets? 
 
 It is not typical for IETF work to address the expectations of entities that are

--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -43,8 +43,7 @@ first milestone of the Working Group.
 
 - Define reusable format(s) for Digital Emblems
 - Define validation mechanism(s) for Digital Emblems
-- Define discovery of Digital Emblems for Digital Assets
-- Define discovery of Digital Emblems for Physical Assets
+- Define discovery mechanism(s) of Digital Emblems
 
 # Deliverables
 The following are proposed deliverables and their target status:

--- a/diem-unified-charter.md
+++ b/diem-unified-charter.md
@@ -41,6 +41,11 @@ already own related scope. Divergent requirements between such stakeholders
 may result in distinct units of work, but this determination is left to this
 first milestone of the Working Group.
 
+- Define reusable format(s) for Digital Emblems
+- Define validation mechanism(s) for Digital Emblems
+- Define discovery of Digital Emblems for Digital Assets
+- Define discovery of Digital Emblems for Physical Assets
+
 # Deliverables
 The following are proposed deliverables and their target status:
 


### PR DESCRIPTION
I think these four bullet points add more confusion than clarity. The paragraph above says that one of the first things the WG will do is decide which streams of work belong together and which don't. These four bullet points could be interpreted as defining the concrete, technical problems to work on (contradicting the previous paragraph).

However,  these bullet point are not referenced anywhere in the text, leaving their meaning open. I think the charter is better off without them.